### PR TITLE
ll_bb_spi_lcd: Fix missing stdint declarations

### DIFF
--- a/lv_bb_spi_lcd.h
+++ b/lv_bb_spi_lcd.h
@@ -6,6 +6,7 @@
 #ifndef LV_BB_SPI_LCD_H
 #define LV_BB_SPI_LCD_H
 
+#include <cstdint>
 #include <bb_spi_lcd.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes these:

```
/home/defer/Downloads/F1Halo/lv_bb_spi_lcd.cpp:9:

/home/defer/Arduino/libraries/bb_spi_lcd/src/bb_spi_lcd.h:27:6: error: variable or field 's3_alpha_blend_be' declared void

   27 | void s3_alpha_blend_be(uint16_t *pFG, uint16_t *pBG, uint16_t *pDest, uint32_t count, uint8_t alpha, const uint16_t *pMasks);

      |      ^~~~~~~~~~~~~~~~~

/home/defer/Arduino/libraries/bb_spi_lcd/src/bb_spi_lcd.h:27:24: error: 'uint16_t' was not declared in this scope

   27 | void s3_alpha_blend_be(uint16_t *pFG, uint16_t *pBG, uint16_t *pDest, uint32_t count, uint8_t alpha, const uint16_t *pMasks);
````