### PR TITLE
disp: Use global var

### DIFF
--- a/F1Halo.ino
+++ b/F1Halo.ino
@@ -237,7 +237,7 @@ void setup() {
   lv_tick_set_cb([](){ 
     return (uint32_t) (esp_timer_get_time() / 1000ULL);
   });
-  lv_display_t* disp = lv_bb_spi_lcd_create(DISPLAY_TYPE);
+  disp = lv_bb_spi_lcd_create(DISPLAY_TYPE);
 
 #ifdef TOUCH_CAPACITIVE
   // Initialize touch screen


### PR DESCRIPTION
brightness set uses this var and it wasn't set.